### PR TITLE
Correct ~/.vim/bundlesVimRc.custom filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Plugin System:
 
 - You can add any plugin you like using the `NeoBundle` command.
 - Add custom plugins using the `NeoBundle` command inside
-  `~/.vim/.bundlesVimRc.custom`.
+  `~/.vim/bundlesVimRc.custom`.
 - Customize `~/.vim/vimrc.custom.before` to configure Vim before any of the
   bundles are loaded, and customize `~/.vim/vimrc.custom.after` to configure
   Vim after plugins are loaded.


### PR DESCRIPTION
Additionally, you may want to remove the documentation inside vimrc.custom.before that says you can put NeoBundle statements in there. I ran into errors trying to do that.